### PR TITLE
Add 3-day stability delay to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: 3 days` to Renovate config

This adds a 3-day stability delay before Renovate creates PRs for new package versions. This protects against supply chain attacks like the [axios compromise on March 31, 2026](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan), where malicious versions were live for ~2-3 hours before being unpublished.

## Test plan
- Renovate should continue to create dependency update PRs, just delayed by 3 days