### PR TITLE
Pin WordPress to 7.0 for deterministic CI (+ block-load timeout headroom)

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress",
+  "core": "WordPress/WordPress#7.0",
   "plugins": ["."],
   "config": {
     "WP_DEBUG": true

--- a/e2e/single_event.spec.ts
+++ b/e2e/single_event.spec.ts
@@ -7,6 +7,10 @@ function uniqueTitle(base: string) {
     return `${base} ${Math.random().toString(36).slice(2, 10)}`;
 }
 
+// The MUI-heavy Create Event block can take several seconds to paint on CI's
+// constrained runner (fast locally). Give block-load waits generous headroom.
+const BLOCK_LOAD_TIMEOUT = 30_000;
+
 test.describe('Event Tests',  () => {
     // Tests share one WordPress instance; each isolates itself with a unique
     // event title (see uniqueTitle) rather than wiping global state, so they
@@ -201,19 +205,24 @@ async function createSingleEvent(
     await page.getByRole('link', { name: 'Events' }).first().click();
     await page.locator('#wpbody-content').getByRole('link', { name: 'Add New Event' }).click();
 
-    await page.locator('#editor').waitFor({ state: 'visible' });
+    await page.locator('#editor').waitFor({ state: 'visible', timeout: BLOCK_LOAD_TIMEOUT });
     const guide = page.locator('.components-guide');
     const eventBlock = page.getByLabel('Block: Create Event');
 
+    // The Create Event block renders a stack of heavy MUI components
+    // (date/time pickers, selectors, editors) synchronously. On CI's
+    // constrained runner this paint can take several seconds, so allow a
+    // generous timeout — the welcome guide is disabled, so its waitFor only
+    // rejects at the timeout and must not lose the race before the block paints.
     const winner = await Promise.race([
-        guide.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'guide'),
-        eventBlock.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'title'),
+        guide.waitFor({ state: 'visible', timeout: BLOCK_LOAD_TIMEOUT }).then(() => 'guide'),
+        eventBlock.waitFor({ state: 'visible', timeout: BLOCK_LOAD_TIMEOUT }).then(() => 'title'),
     ]);
 
     if (winner === 'guide') {
         await page.keyboard.press('Escape');
         await expect(guide).toBeHidden();
-        await eventBlock.waitFor({ state: 'visible' });
+        await eventBlock.waitFor({ state: 'visible', timeout: BLOCK_LOAD_TIMEOUT });
     }
 
     // Fill in event details


### PR DESCRIPTION
The Create Event block renders many MUI components synchronously (~544KB bundle). On CI's constrained runner this paint takes several seconds (instant locally), so the 5s block-load waits in `createSingleEvent` timed out — and because the welcome guide is disabled, its `waitFor` rejection won the `Promise.race` before the block painted, failing nearly every event test.

Trace analysis confirmed navigation/scripts/API are all fast (<300ms); only the block paint is slow. Bumps the editor/guide/block-load waits to 30s.

This is why #28 passed once (fast runner) but the rebased Renovate PRs fail — same flaky wait. Landing this unblocks them.