### PR TITLE
Add auto-merge, release and nightly CI workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Skip release PRs - they need a manual merge to trigger the release workflow
+    # (auto-merge uses GITHUB_TOKEN, which does not trigger downstream workflows)
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge ${{ github.event.pull_request.number }} --auto --merge --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,72 @@
+name: Nightly Release
+
+on:
+  schedule:
+    # Run daily at 2:00 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get current version and date
+        id: version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          DATE=$(date +'%Y%m%d')
+          NIGHTLY_VERSION="${CURRENT_VERSION}-nightly.${DATE}"
+          echo "nightly_version=${NIGHTLY_VERSION}" >> $GITHUB_OUTPUT
+          echo "date=${DATE}" >> $GITHUB_OUTPUT
+
+      # publish.js excludes every block's src/, so the block bundles must be
+      # built before the zip is created or the plugin ships without its JS.
+      - name: Build blocks
+        run: npm run build
+
+      - name: Build package
+        run: |
+          # Skip the i18n build for nightly (it requires a running wp-env)
+          node ./publish.js
+
+      - name: Delete previous nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all releases with 'nightly' in the tag
+          NIGHTLY_RELEASES=$(gh release list --json tagName --jq '.[] | select(.tagName | contains("nightly")) | .tagName')
+          for tag in $NIGHTLY_RELEASES; do
+            echo "Deleting release: $tag"
+            gh release delete "$tag" --yes --cleanup-tag || true
+          done
+
+      - name: Create nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.nightly_version }}" \
+            --title "Nightly Build ${{ steps.version.outputs.date }}" \
+            --notes "Automated nightly build from main branch.
+
+          **Version:** ${{ steps.version.outputs.nightly_version }}
+          **Built from:** ${{ github.sha }}
+
+          This is a pre-release build for testing purposes." \
+            --prerelease \
+            *.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check release conditions
+        id: check
+        run: |
+          # Check if current commit has a semver tag
+          TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+          # Check if commit is on main
+          ON_MAIN=$(git branch -r --contains HEAD | grep -q 'origin/main' && echo "true" || echo "false")
+
+          if [ -z "$TAG" ]; then
+            echo "No release tag found on this commit"
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          elif [ "$ON_MAIN" != "true" ]; then
+            echo "Tagged commit is not on main branch yet"
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "Found release tag on main: $TAG"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        if: steps.check.outputs.should_release == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check.outputs.should_release == 'true'
+        run: npm ci
+
+      # publish.js excludes every block's src/, so the block bundles must be
+      # built before the zip is created or the plugin ships without its JS.
+      - name: Build blocks
+        if: steps.check.outputs.should_release == 'true'
+        run: npm run build
+
+      - name: Build package
+        if: steps.check.outputs.should_release == 'true'
+        run: node ./publish.js
+
+      - name: Generate release notes
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          # Get previous tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+          if [ -z "$PREV_TAG" ]; then
+            # First release, get all commits
+            COMMITS=$(git log --pretty=format:"- %s" --no-merges)
+          else
+            # Get commits since previous tag
+            COMMITS=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --no-merges)
+          fi
+
+          # Write to file for multiline output
+          echo "## Changes" > release_notes.md
+          echo "" >> release_notes.md
+          echo "$COMMITS" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "---" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "**Full Changelog:** https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${{ steps.check.outputs.tag }}" >> release_notes.md
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.check.outputs.tag }}" \
+            --title "Release ${{ steps.check.outputs.version }}" \
+            --notes-file release_notes.md \
+            *.zip

--- a/publish.js
+++ b/publish.js
@@ -11,14 +11,17 @@ files.forEach(file => {
     }
 });
 
-// Step 2a: Read the readme.md file
-const readmeContent = fs.readFileSync(path.join(__dirname, 'readme.md'), 'utf8');
+// Step 2a: Read the README.md file
+// NOTE: the tracked filename is README.md. Reading 'readme.md' only works on a
+// case-insensitive filesystem (macOS) and throws ENOENT on the Linux runners
+// used by release.yml / nightly.yml.
+const readmeContent = fs.readFileSync(path.join(__dirname, 'README.md'), 'utf8');
 
 // Step 2b: Extract Plugin Name and Current Version using regex
 const pluginNameMatch = readmeContent.match(/~Plugin Name:\s*(.+?)~/);
 
 if (!pluginNameMatch) {
-    throw new Error('Could not find Plugin Name or Current Version in readme.md');
+    throw new Error('Could not find Plugin Name or Current Version in README.md');
 }
 
 const pluginName = pluginNameMatch[1].trim();


### PR DESCRIPTION
Brings this repo in line with the shared Soli CI setup (reference: `wp-soli-clean-theme/.github/workflows/`). Until now this repo only had `e2e.yaml`, which is why green renovate PRs have been idling since March instead of merging themselves.

## Added

| Workflow | What it does |
|---|---|
| `auto-merge.yml` | Enables auto-merge on every PR **except** `release/*`. Release PRs are skipped because auto-merge runs as `GITHUB_TOKEN`, which does not trigger the downstream release workflow. |
| `release.yml` | On a `vX.Y.Z` tag that sits on `main`: builds the distribution zip and creates the GitHub Release with notes generated from the commits since the previous tag. |
| `nightly.yml` | Daily 02:00 UTC pre-release build (`{version}-nightly.{YYYYMMDD}`), deleting the previous nightly so only the latest is kept. |

## Adaptations vs. the reference implementation

- **node 20 + `actions/*@v4`** instead of node 24 + `@v6`, matching the existing `e2e.yaml` in this repo rather than introducing a second toolchain.
- **Explicit `npm run build` before `node ./publish.js`** in both `release.yml` and `nightly.yml`. `publish.js` excludes `**/src/**` and the block `build/` output is gitignored, so without a build the zip would ship the plugin without any block JS. The reference theme has no block bundles and therefore does not need this step.
- **`publish.js` now reads `README.md`, not `readme.md`.** The tracked filename is uppercase; the lowercase path only resolves on a case-insensitive filesystem (macOS), so `publish.js` would have thrown `ENOENT` on the Linux runners the moment `release.yml`/`nightly.yml` first ran. Smoke-tested locally: the zip still builds.

No version bump — the four version locations are untouched.

## Status check naming

`e2e.yaml` is deliberately left as-is in this PR. Its status check context is `e2e` (the job id), which is what the existing `automerge` branch ruleset requires; renaming the workflow or its job would break that ruleset and could strand the open renovate PRs. See the accompanying report for the rename recommendation.