### PR TITLE
Allow the e2e workflow to be dispatched manually

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  # Manual re-run. Needed because auto-merge.yml merges as GITHUB_TOKEN, and
+  # pushes made by GITHUB_TOKEN do not trigger workflows - so a bot-merged PR
+  # leaves main without a push run. This lets main be re-verified on demand.
+  workflow_dispatch:
 
 jobs:
   e2e:


### PR DESCRIPTION
`auto-merge.yml` merges PRs as `GITHUB_TOKEN`, and **pushes made by `GITHUB_TOKEN` do not trigger workflows**. A bot-merged PR therefore lands on `main` without a push run.

This was observed for real while draining the renovate queue: PRs merged by `app/github-actions` (#16, #17, #19, #20, #25, #26, #27) produced no `E2E (Playwright on wp-env)` run on main, while #33 — auto-merge enabled with a user token, so merged as `JoranOut` — triggered both the E2E and Release runs. After ten lockfile merges, main was left without a green signal of its own.

Adding `workflow_dispatch` makes it possible to re-run the suite against `main` on demand, which closes that gap without weakening anything.

The job id stays **`e2e`** so the `required_status_checks` context in the branch ruleset keeps matching. No version bump.