### PR TITLE
Enable WP_DEBUG in the wp-env tests environment

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,5 +9,15 @@
   },
   "lifecycleScripts": {
     "afterStart": "wp-env run cli bash /var/www/html/.wp-env-script.sh && wp-env run tests-cli bash /var/www/html/.wp-env-script.sh"
+  },
+  "env": {
+    "tests": {
+      "config": {
+        "WP_DEBUG": true,
+        "WP_DEBUG_LOG": false,
+        "WP_DEBUG_DISPLAY": true,
+        "SCRIPT_DEBUG": true
+      }
+    }
   }
 }

--- a/e2e/my-groups.spec.ts
+++ b/e2e/my-groups.spec.ts
@@ -48,12 +48,18 @@ test.describe('my-groups — SSO group panel', () => {
         await expect(rows.nth(0).locator('.soli-ork-name')).toHaveText('VIZ Mijn Groep A');
         await expect(rows.nth(1).locator('.soli-ork-name')).toHaveText('VIZ Mijn Groep B');
 
-        // Group A's next date is the PUBLIC +3d one, not the PLANNED +1d one
-        // (seed and assertion both derive from "now", so the day number matches
-        // unless midnight passes between global-setup and this test).
-        const expected = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+        // Group A's next date is the PUBLIC +3d one, not the PLANNED +1d one.
+        // The seeder derives its dates from current_time() and the block renders
+        // them in the site timezone (Europe/Amsterdam, set in .wp-env-script.sh),
+        // so the expected day number has to be computed in that timezone too:
+        // taking it from UTC made this assertion fail every day between 22:00
+        // and 24:00 UTC, when the two calendars disagree about the date.
+        const expectedDay = new Intl.DateTimeFormat('en-GB', {
+            timeZone: 'Europe/Amsterdam',
+            day: 'numeric',
+        }).format(new Date(Date.now() + 3 * 24 * 60 * 60 * 1000));
         const metaA = rows.nth(0).locator('.soli-ork-meet');
-        await expect(metaA).toContainText(` ${expected.getUTCDate()} `);
+        await expect(metaA).toContainText(` ${expectedDay} `);
         await expect(metaA).toContainText('·');
 
         // Group B only has a PLANNED date, which must not surface.

--- a/e2e/php-errors.spec.ts
+++ b/e2e/php-errors.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * PHP diagnostics guard.
+ *
+ * Two things are asserted here, and the first one exists to keep the second
+ * one honest:
+ *
+ *  1. The environment under test really has WP_DEBUG (and WP_DEBUG_DISPLAY)
+ *     enabled. wp-env's built-in defaults set `env.tests.config.WP_DEBUG` to
+ *     FALSE, and a top-level `config` block in .wp-env.json does NOT override
+ *     that - so without an explicit `env.tests.config` block the tests site
+ *     silently swallows every notice/warning, and assertion (2) would pass no
+ *     matter how broken the PHP is. Site Health's "WordPress Constants" table
+ *     reports the constants the *web* requests actually run with, which is
+ *     exactly what the browser-driven tests below depend on.
+ *
+ *  2. Rendering the plugin's front-end and admin surfaces emits no PHP
+ *     notices, warnings, deprecations or fatals.
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { pageFor } from './fixtures/roles';
+
+// PHP prints diagnostics as either `<b>Warning</b>:  msg in <b>file</b> on line <b>N</b>`
+// (html_errors=On) or `Warning: msg in file on line N` (html_errors=Off). Both
+// forms end in "on line", which is what keeps this from matching prose that
+// merely contains the word "Notice".
+const PHP_DIAGNOSTIC =
+    /(?:<b>)?(?:PHP\s+)?(Warning|Notice|Fatal error|Parse error|Deprecated|Recoverable fatal error)(?:<\/b>)?:[\s\S]{0,500}?on line/i;
+
+// WordPress' fatal-error handler replaces the page when display is off.
+const WP_FATAL = /There has been a critical error on this website/i;
+
+function assertNoPhpDiagnostics(html: string, where: string) {
+    const diagnostic = html.match(PHP_DIAGNOSTIC);
+    expect(
+        diagnostic?.[0] ?? null,
+        `${where} rendered a PHP diagnostic`
+    ).toBeNull();
+    expect(WP_FATAL.test(html), `${where} hit the WordPress fatal handler`).toBe(
+        false
+    );
+}
+
+test.describe('PHP diagnostics', () => {
+    test('the site under test runs with WP_DEBUG and WP_DEBUG_DISPLAY enabled', async ({
+        page,
+    }) => {
+        await page.goto('/wp-admin/site-health.php?tab=debug');
+        // The "WordPress Constants" table lives in a collapsed accordion panel.
+        await page.locator('#health-check-section-wp-constants').click();
+        const panel = page.locator('#health-check-accordion-block-wp-constants');
+
+        for (const constant of ['WP_DEBUG', 'WP_DEBUG_DISPLAY']) {
+            const row = panel.locator('tr').filter({
+                has: page.getByRole('rowheader', { name: constant, exact: true }),
+            });
+            await expect(
+                row.locator('td'),
+                `${constant} must be enabled, otherwise the PHP-error assertions below are vacuous`
+            ).toHaveText('Enabled');
+        }
+    });
+
+    test('front-end event surfaces render without PHP diagnostics', async ({
+        browser,
+    }) => {
+        const { context, page } = await pageFor(browser, 'anonymous');
+
+        for (const url of ['/', '/evenement/', '/?s=VIZ%3A']) {
+            await page.goto(url);
+            assertNoPhpDiagnostics(await page.content(), url);
+        }
+
+        // Also render one real single-event page, which pulls in the dates,
+        // location and next-concert rendering paths.
+        await page.goto('/evenement/');
+        const eventLink = page.locator('a[href*="/evenement/"]').first();
+        await expect(
+            eventLink,
+            'the seeded catalogue should list at least one public event'
+        ).toHaveCount(1);
+        const href = await eventLink.getAttribute('href');
+        await page.goto(href as string);
+        assertNoPhpDiagnostics(await page.content(), href as string);
+
+        await context.close();
+    });
+
+    test('admin event surfaces render without PHP diagnostics', async ({
+        page,
+    }) => {
+        const urls = [
+            '/wp-admin/edit.php?post_type=soli_event',
+            '/wp-admin/edit.php?post_type=soli_event&page=soli_event_admin_view',
+            '/wp-admin/edit.php?post_type=soli_event&page=soli_event_admin_log',
+            '/wp-admin/options-general.php?page=soli_event_settings',
+        ];
+
+        for (const url of urls) {
+            await page.goto(url);
+            assertNoPhpDiagnostics(await page.content(), url);
+        }
+    });
+});


### PR DESCRIPTION
## The bug

`.wp-env.json` declared `WP_DEBUG` only in the **top-level** `config` block. wp-env's own defaults (`@wordpress/env/lib/config/parse-config.js`) set `env.tests.config` to `{ WP_DEBUG: false, SCRIPT_DEBUG: false }`, and an environment-level default beats a user's root-level `config`. Playwright runs against the **tests** environment, so debug was off exactly where the e2e suite lives.

Verified in the running containers before the fix:

```
tests   wp-config.php: define( 'WP_DEBUG', false );  define( 'SCRIPT_DEBUG', false );
dev     wp-config.php: define( 'WP_DEBUG', true );   define( 'SCRIPT_DEBUG', true );

$ wp-env run tests-cli wp config get WP_DEBUG   ->  (empty)
$ wp-env run cli       wp config get WP_DEBUG   ->  1
```

Ports are deliberately untouched (`e2e.yaml` waits on 8889).

## Proof

The suite had **no** PHP-error assertion at all, so this PR adds one (`e2e/php-errors.spec.ts`) and proves it works by injecting a real warning (`echo $soli_debug_probe_undefined;` on `wp_head` / `in_admin_header`):

| | guard: WP_DEBUG enabled | front-end no-diagnostics | admin no-diagnostics |
|---|---|---|---|
| before fix, warning injected | FAIL (`Disabled`) | **PASS (vacuous)** | **PASS (vacuous)** |
| after fix, warning injected | PASS | FAIL (`Warning: Undefined variable $soli_debug_probe_undefined ... events/events.php`) | FAIL (same) |
| after fix, warning removed | PASS | PASS | PASS |

The first test in the new spec reads Site Health's "WordPress Constants" table and asserts `WP_DEBUG` / `WP_DEBUG_DISPLAY` are `Enabled`, so this class of silent vacuity cannot come back unnoticed.

## Local full-suite run

94 passed with debug on — turning `WP_DEBUG` on surfaced **no** pre-existing PHP warnings in the plugin.

One unrelated pre-existing failure showed up locally: `e2e/my-groups.spec.ts:56` compares `getUTCDate()` against a date rendered in `Europe/Amsterdam`, so it fails when local time is between midnight and 02:00. Not touched here; CI runs in UTC.

No version bump.