### PR TITLE
ci: rename the e2e workflow and job to test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: E2E (Playwright on wp-env)
+name: Test
 
 on:
   pull_request:
@@ -10,7 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e:
+  # Job id is the required status check context (must match the "PR requirements"
+  # ruleset, and the `test` name used across all Soli repos). The workflow name
+  # never appears as a check context.
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/projects/code-review-remediation-plan.md
+++ b/projects/code-review-remediation-plan.md
@@ -206,7 +206,7 @@ Not yet pushed / no PRs opened — awaiting go-ahead.
 - **Acceptance:** Import gone; bundle + `*.asset.php` deps clean.
 
 ### 4.5 Editor `index.php` fixes for CI-verifiable download of build artifacts
-- Confirm the E2E workflow (`.github/workflows/e2e.yaml`) still builds and passes after workspace fix. Consider committing build artifacts only if the release process depends on them (currently `build/` is not tracked — keep it that way and rely on the build step).
+- Confirm the E2E workflow (`.github/workflows/test.yml`) still builds and passes after workspace fix. Consider committing build artifacts only if the release process depends on them (currently `build/` is not tracked — keep it that way and rely on the build step).
 
 ---
 


### PR DESCRIPTION
Renames this repo's CI check from `e2e` to `test` so it matches every other Soli repo, letting the root `CLAUDE.md` drop its documented exception.

### Changes
- `.github/workflows/e2e.yaml` → `.github/workflows/test.yml`
- workflow `name:` `E2E (Playwright on wp-env)` → `Test`
- **job id `e2e` → `test`** — the job id is what becomes the check context; the workflow name never appears as one
- fixed a stale `e2e.yaml` path reference in `projects/code-review-remediation-plan.md`

### What is deliberately unchanged
The workflow body is kept verbatim. It does strictly more than the reference `test.yml` in `wp-soli-featured-image-plugin`, and none of it is dropped: `npm run build` for the blocks, the wait loop on the tests site at `:8889`, the traces/videos artifact upload alongside the HTML report, and the `if: always()` wp-env teardown. The `workflow_dispatch` trigger (added so `main` can be re-verified after a `GITHUB_TOKEN` bot merge) and `push: branches: [main]` are both kept. No version bump, no `.wp-env.json` change.

### Ruleset coordination
This cannot be done atomically: the PR reports `test` while the ruleset still required `e2e`, so it would block forever; requiring both also blocks, because only one context ever reports. The `PR requirements` ruleset was therefore switched from `e2e` to `test` immediately before this PR was opened, leaving `main` briefly with a required check nothing reports. The `pull_request`, `non_fast_forward` and `deletion` rules were left untouched.