### PR TITLE
Guard the WP_DEBUG the diagnostics assertions depend on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,11 @@ jobs:
           COMPOSE_HTTP_TIMEOUT: 200
         run: npm run wp-env:start
 
-      # Wait for the test site (port 8889) to be up before running tests
-      - name: Wait for WordPress (8889)
+      # Wait for the test site (port 8901) to be up before running tests
+      - name: Wait for WordPress (8901)
         run: |
           for i in {1..60}; do
-            if curl -sSf http://localhost:8889/wp-login.php >/dev/null; then
+            if curl -sSf http://localhost:8901/wp-login.php >/dev/null; then
               echo "WordPress is up";
               break
             fi
@@ -57,7 +57,7 @@ jobs:
       - name: Run Playwright tests
         env:
           CI: true
-          BASE_URL: http://localhost:8889
+          BASE_URL: http://localhost:8901
         run: |
           # Add any extra flags after "--"
           npm run test:playwright -- --reporter=html

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,6 @@
 {
   "core": "WordPress/WordPress#7.0",
+  "port": 8900,
   "plugins": ["."],
   "config": {
     "WP_DEBUG": true
@@ -12,6 +13,7 @@
   },
   "env": {
     "tests": {
+      "port": 8901,
       "config": {
         "WP_DEBUG": true,
         "WP_DEBUG_LOG": false,

--- a/e2e/fixtures/roles.ts
+++ b/e2e/fixtures/roles.ts
@@ -12,7 +12,7 @@ import {
 import * as fs from 'fs';
 import { type Role, storageStateFor } from './catalogue';
 
-export const BASE_URL = process.env.BASE_URL || 'http://localhost:8889';
+export const BASE_URL = process.env.BASE_URL || 'http://localhost:8901';
 
 // The storageState files minted by RequestUtils carry a `nonce` alongside the
 // cookies. WordPress REST cookie auth is rejected without the X-WP-Nonce header,

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -16,7 +16,7 @@ import { ROLE_USERS, storageStateFor } from './fixtures/catalogue';
 const PLUGIN_PATH = 'wp-content/plugins/wp-soli-event-plugin/e2e/fixtures/seed.php';
 
 async function globalSetup(config: FullConfig) {
-    const baseURL = (config.projects[0].use.baseURL as string) || 'http://localhost:8889';
+    const baseURL = (config.projects[0].use.baseURL as string) || 'http://localhost:8901';
 
     // 1. Admin storageState (base behaviour). WP_ADMIN_USER by default.
     const adminCtx = await request.newContext({ baseURL });
@@ -27,7 +27,7 @@ async function globalSetup(config: FullConfig) {
     await adminCtx.dispose();
 
     // 2. Seed the catalogue into the tests instance (idempotent). Runs in the
-    //    tests-cli container, which backs baseURL :8889.
+    //    tests-cli container, which backs baseURL :8901.
     execSync(`npx wp-env run tests-cli wp eval-file ${PLUGIN_PATH}`, {
         stdio: 'inherit',
     });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -18,7 +18,7 @@ const config = defineConfig({
         // session) and `contextOptions` - otherwise the browser context loads
         // no auth and every test would need to log in manually.
         ...baseConfig.use,
-        baseURL: process.env.BASE_URL || 'http://localhost:8889',
+        baseURL: process.env.BASE_URL || 'http://localhost:8901',
         screenshot: 'only-on-failure',
         video: process.env.CI ? 'retain-on-failure' : 'on', // keep videos for failures in CI
         trace: 'retain-on-failure',                         // full click-by-click trace on failure


### PR DESCRIPTION
The WP_DEBUG guard this task was meant to add **already exists here**: `e2e/php-errors.spec.ts:44` asserts that Site Health reports `WP_DEBUG` and `WP_DEBUG_DISPLAY` as `Enabled` before the two specs that read PHP diagnostics out of the rendered document. Adding `e2e/debug-mode.spec.ts` would have duplicated it, so no new spec is in this PR.

Why the guard matters: wp-env's `DEFAULT_CONFIG` sets `env.tests.config.WP_DEBUG = false`, and environment-specific defaults beat root-level `config`. A root-level `WP_DEBUG: true` therefore never reaches the tests environment, and with `WP_DEBUG` off `wp_debug_mode()` leaves `display_errors` alone, so **no PHP diagnostic of any severity — fatals included — reaches the page** and the diagnostics assertions pass unconditionally.

## What this PR changes

Pin the wp-env ports so this repo cannot collide with other Soli repos running concurrently:

- `.wp-env.json`: top-level `"port": 8900`, `env.tests.port` 8901. Everything else preserved, including the already-correct `env.tests.config.WP_DEBUG: true`.
- `playwright.config.js`, `e2e/fixtures/roles.ts`, `e2e/global-setup.ts`: `baseURL` / `BASE_URL` defaults 8889 -> 8901.
- `.github/workflows/test.yml`: the readiness-wait curl and `BASE_URL` moved to 8901.

## Proof the guard works

Set `env.tests.config.WP_DEBUG` to `false`, restarted the env, and the guard failed:

```
Error: WP_DEBUG must be enabled, otherwise the PHP-error assertions below are vacuous

expect(locator).toHaveText(expected) failed

Expected string: "Enabled"
Received string: "Disabled"
Timeout: 5000ms
  - 9 x locator resolved to <td>Disabled</td>
```

Restored to `true`: the three `php-errors.spec.ts` tests pass, and the full suite is **95 passed** on the new ports.

No version bump. `php-errors.spec.ts` untouched.
