### PR TITLE
Make the updater resolve releases instead of branch headers

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,33 @@ jobs:
           echo "nightly_version=${NIGHTLY_VERSION}" >> $GITHUB_OUTPUT
           echo "date=${DATE}" >> $GITHUB_OUTPUT
 
+      - name: Stamp nightly version
+        env:
+          V: ${{ steps.version.outputs.nightly_version }}
+        run: |
+          set -euo pipefail
+          # publish.js zips what is on disk, so the nightly version has to be
+          # written into the version locations *before* the build. Without this
+          # the zip reports the stable version, no site can tell a nightly from
+          # a stable install, and the updater's channel split cannot engage.
+          # Working tree only - nothing is committed back to the repo.
+          sed -i -E "s|^(  Version: ).*$|\1${V}|" soli-event-plugin.php
+          sed -i -E "s|(SOLI_EVENT__PLUGIN_VERSION', \")[^\"]*(\")|\1${V}\2|" soli-event-plugin.php
+          sed -i -E "s|(~Current Version:[[:space:]]*)[^~]*(~)|\1${V}\2|" README.md
+          # package.json is excluded from the zip, but keep it consistent so a
+          # later change to publish.js's ignore list cannot reintroduce a drift.
+          node -e 'const f="package.json",p=require("./"+f);p.version=process.argv[1];require("fs").writeFileSync(f,JSON.stringify(p,null,2)+"\n")' "$V"
+
+          # Fail loudly rather than shipping a mis-stamped zip.
+          grep -qF -- "  Version: ${V}" soli-event-plugin.php \
+            || { echo "::error::failed to stamp the plugin header version"; exit 1; }
+          grep -qF -- "SOLI_EVENT__PLUGIN_VERSION', \"${V}\"" soli-event-plugin.php \
+            || { echo "::error::failed to stamp SOLI_EVENT__PLUGIN_VERSION"; exit 1; }
+          grep -qE -- "~Current Version:[[:space:]]*${V}~" README.md \
+            || { echo "::error::failed to stamp the version into README.md"; exit 1; }
+          test "$(node -p "require('./package.json').version")" = "$V"
+          echo "Stamped $V into all version locations."
+
       # publish.js excludes every block's src/, so the block bundles must be
       # built before the zip is created or the plugin ships without its JS.
       - name: Build blocks

--- a/soli-event-plugin.php
+++ b/soli-event-plugin.php
@@ -66,9 +66,11 @@ add_action('init', function () {
       'slug' => plugin_basename(__FILE__), // this is the slug of your plugin
       'proper_folder_name' => dirname( plugin_basename( __FILE__ ) ), // this is the name of the folder your plugin lives in
       'api_url' => 'https://api.github.com/repos/JoranOut/wp-soli-event-plugin', // the GitHub API url of your GitHub repo
-      'raw_url' => 'https://raw.github.com/JoranOut/wp-soli-event-plugin/main', // the GitHub raw url of your GitHub repo
+      'raw_url' => 'https://raw.githubusercontent.com/JoranOut/wp-soli-event-plugin/main', // the GitHub raw url of your GitHub repo
       'github_url' => 'https://github.com/JoranOut/wp-soli-event-plugin', // the GitHub url of your GitHub repo
-      'zip_url' => 'https://github.com/JoranOut/wp-soli-event-plugin/archive/refs/heads/main.zip', // the zip url of the GitHub repo
+      // Fallback only. The updater resolves the real download from the GitHub
+      // releases API and overrides this with the release's zip asset.
+      'zip_url' => 'https://github.com/JoranOut/wp-soli-event-plugin/releases/latest/download/wp-soli-event-plugin.zip', // the zip url of the GitHub repo
       'sslverify' => true, // whether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
       'requires' => '6.0.0', // which version of WordPress does your plugin require?
       'tested' => '6.6.6',  // which version of WordPress is your plugin tested up to?

--- a/updater.php
+++ b/updater.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists
 /**
  *
  *
- * @version 1.6
+ * @version 1.7
  * @author Joachim Kudish <info@jkudish.com>
  * @link http://jkudish.com
  * @package WP_GitHub_Updater
@@ -38,7 +38,7 @@ class WP_GitHub_Updater {
 	/**
 	 * GitHub Updater version
 	 */
-	const VERSION = 1.6;
+	const VERSION = 1.7;
 
 	/**
 	 * @var $config the config for the updater
@@ -57,6 +57,24 @@ class WP_GitHub_Updater {
 	 * @access private
 	 */
 	private $github_data;
+
+	/**
+	 * @var $releases_data temporarily store the releases fetched from GitHub, allows us to only load the data once per class instance
+	 * @access private
+	 */
+	private $releases_data;
+
+	/**
+	 * @var $channel_release temporarily store the resolved release for the installed version's channel
+	 * @access private
+	 */
+	private $channel_release;
+
+	/**
+	 * @var $remote_resolved whether the GitHub lookups have already run this request
+	 * @access private
+	 */
+	private $remote_resolved = false;
 
 
 	/**
@@ -152,16 +170,9 @@ class WP_GitHub_Updater {
 			$this->config['zip_url'] = $zip_url;
 		}
 
-
-		if ( ! isset( $this->config['new_version'] ) )
-			$this->config['new_version'] = $this->get_new_version();
-
-		if ( ! isset( $this->config['last_updated'] ) )
-			$this->config['last_updated'] = $this->get_date();
-
-		if ( ! isset( $this->config['description'] ) )
-			$this->config['description'] = $this->get_description();
-
+		// Local data only - nothing here may touch the network, see
+		// resolve_remote(). Reading the installed version is what lets that
+		// later lookup pick a channel, so it has to happen first.
 		$plugin_data = $this->get_plugin_data();
 		if ( ! isset( $this->config['plugin_name'] ) )
 			$this->config['plugin_name'] = $plugin_data['Name'];
@@ -178,6 +189,48 @@ class WP_GitHub_Updater {
 		if ( ! isset( $this->config['readme'] ) )
 			$this->config['readme'] = 'README.md';
 
+	}
+
+
+	/**
+	 * Resolve everything that needs a call to GitHub
+	 *
+	 * Deliberately not called from the constructor. set_defaults() runs on
+	 * `init` for every wp-admin request, so resolving there cost two API calls
+	 * per admin page view - against GitHub's unauthenticated limit of 60 per
+	 * hour, counted per source IP rather than per site or per plugin. That is
+	 * roughly 30 page views an hour for a single plugin, and about 2.5 once a
+	 * dozen plugins on the same host each do it, at which point every site on
+	 * that IP starts reading stale data it cannot refresh.
+	 *
+	 * WordPress only needs any of this when it actually checks for updates -
+	 * every 12 hours, or on an explicit force-check - so resolve on first use
+	 * and memoise for the rest of the request.
+	 *
+	 * @since 1.7
+	 * @return void
+	 */
+	public function resolve_remote() {
+		if ( $this->remote_resolved )
+			return;
+
+		$this->remote_resolved = true;
+
+		$release = $this->get_channel_release();
+
+		if ( ! isset( $this->config['new_version'] ) )
+			$this->config['new_version'] = ( false === $release ) ? false : $release['version'];
+
+		// Point the download at the release's built zip asset rather than at a
+		// branch archive, so the update installs what CI actually packaged.
+		if ( false !== $release && ! empty( $release['package'] ) )
+			$this->config['zip_url'] = $release['package'];
+
+		if ( ! isset( $this->config['last_updated'] ) )
+			$this->config['last_updated'] = $this->get_date();
+
+		if ( ! isset( $this->config['description'] ) )
+			$this->config['description'] = $this->get_description();
 	}
 
 
@@ -200,7 +253,13 @@ class WP_GitHub_Updater {
 	 * @return mixed
 	 */
 	public function http_request_sslverify( $args, $url ) {
-		if ( $this->config[ 'zip_url' ] == $url )
+		// The download happens in a later request than the update check, so
+		// config['zip_url'] may still hold the unresolved fallback by then -
+		// match any URL on the repo instead. Never resolve from inside this
+		// filter: it runs on every HTTP request, including our own, and would
+		// recurse.
+		if ( $this->config[ 'zip_url' ] == $url
+			|| ( ! empty( $this->config['github_url'] ) && 0 === strpos( $url, $this->config['github_url'] ) ) )
 			$args[ 'sslverify' ] = $this->config[ 'sslverify' ];
 
 		return $args;
@@ -208,54 +267,139 @@ class WP_GitHub_Updater {
 
 
 	/**
-	 * Get New Version from GitHub
+	 * Whether a version string belongs to the nightly channel
 	 *
-	 * @since 1.0
-	 * @return int $version the version number
+	 * Nightly builds are versioned `{stable}-nightly.{YYYYMMDD}` by
+	 * .github/workflows/nightly.yml, which stamps that version into the
+	 * plugin header of the zip it ships. A site is therefore on the nightly
+	 * channel exactly when its installed version carries that suffix.
+	 *
+	 * @since 1.7
+	 * @param string $version the version to classify
+	 * @return bool
 	 */
-	public function get_new_version() {
-		$version = get_site_transient( md5($this->config['slug']).'_new_version' );
+	public function is_nightly_version( $version ) {
+		return (bool) preg_match( '/-nightly\./i', (string) $version );
+	}
 
-		if ( $this->overrule_transients() || ( !isset( $version ) || !$version || '' == $version ) ) {
 
-			$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . basename( $this->config['slug'] ) );
+	/**
+	 * Get the repository's releases from the GitHub API
+	 *
+	 * @since 1.7
+	 * @return array|false $releases the releases, or false when unavailable
+	 */
+	public function get_releases() {
+		if ( isset( $this->releases_data ) && ! empty( $this->releases_data ) )
+			return $this->releases_data;
 
-			if ( is_wp_error( $raw_response ) )
-				$version = false;
+		$transient_key = md5( $this->config['slug'] ) . '_releases';
+		$cached = get_site_transient( $transient_key );
 
-			if (is_array($raw_response)) {
-				if (!empty($raw_response['body']))
-					preg_match( '/.*Version\:\s*(.*)$/mi', $raw_response['body'], $matches );
-			}
+		if ( ! $this->overrule_transients() && ! empty( $cached ) ) {
+			$this->releases_data = $cached;
+			return $cached;
+		}
 
-			if ( empty( $matches[1] ) )
-				$version = false;
-			else
-				$version = $matches[1];
+		$response = $this->remote_get( trailingslashit( $this->config['api_url'] ) . 'releases' );
 
-			// back compat for older readme version handling
-			// only done when there is no version found in file name
-			if ( false === $version ) {
-				$raw_response = $this->remote_get( trailingslashit( $this->config['raw_url'] ) . $this->config['readme'] );
+		// An API failure - a rate limit above all, since the unauthenticated
+		// limit is 60/hour and WP_GITHUB_FORCE_UPDATE re-checks on every admin
+		// page load - must not be reported as "no update available". Fall back
+		// to the last known good list instead.
+		if ( is_wp_error( $response ) || 200 != wp_remote_retrieve_response_code( $response ) )
+			return empty( $cached ) ? false : $cached;
 
-				if ( is_wp_error( $raw_response ) )
-					return $version;
+		$releases = json_decode( wp_remote_retrieve_body( $response ) );
 
-				preg_match( '#^\s*`*~Current Version\:\s*([^~]*)~#im', $raw_response['body'], $__version );
+		if ( ! is_array( $releases ) )
+			return empty( $cached ) ? false : $cached;
 
-				if ( isset( $__version[1] ) ) {
-					$version_readme = $__version[1];
-					if ( -1 == version_compare( $version, $version_readme ) )
-						$version = $version_readme;
+		// refresh every 6 hours
+		set_site_transient( $transient_key, $releases, 60*60*6 );
+
+		$this->releases_data = $releases;
+
+		return $releases;
+	}
+
+
+	/**
+	 * Resolve the newest release within the installed version's channel
+	 *
+	 * A stable install only ever sees stable releases and a nightly install
+	 * only ever sees nightlies, so a site cannot cross channels by accident.
+	 * Without this filter a nightly install would be offered the stable build
+	 * as an "update", because version_compare() sorts `2.0.3-nightly.20260809`
+	 * below `2.0.3`.
+	 *
+	 * @since 1.7
+	 * @return array|false $release with keys 'version' and 'package', or false
+	 */
+	public function get_channel_release() {
+		if ( isset( $this->channel_release ) )
+			return $this->channel_release;
+
+		$releases = $this->get_releases();
+
+		if ( empty( $releases ) )
+			return false;
+
+		$want_nightly = $this->is_nightly_version( $this->config['version'] );
+		$best = false;
+
+		foreach ( $releases as $release ) {
+
+			if ( ! empty( $release->draft ) )
+				continue;
+
+			$version = ltrim( isset( $release->tag_name ) ? $release->tag_name : '', 'vV' );
+
+			if ( '' === $version )
+				continue;
+
+			if ( $this->is_nightly_version( $version ) !== $want_nightly )
+				continue;
+
+			// Only a release carrying a built zip asset is installable; the
+			// GitHub source zipball is an unbuilt tree and would ship a plugin
+			// without its compiled block assets.
+			$package = '';
+
+			if ( ! empty( $release->assets ) ) {
+				foreach ( $release->assets as $asset ) {
+					if ( ! empty( $asset->name ) && '.zip' === strtolower( substr( $asset->name, -4 ) ) ) {
+						$package = $asset->browser_download_url;
+						break;
+					}
 				}
 			}
 
-			// refresh every 6 hours
-			if ( false !== $version )
-				set_site_transient( md5($this->config['slug']).'_new_version', $version, 60*60*6 );
+			if ( '' === $package )
+				continue;
+
+			// GitHub returns releases newest-created first, but order by
+			// version so a re-published older tag cannot win.
+			if ( false === $best || 1 === version_compare( $version, $best['version'] ) )
+				$best = array( 'version' => $version, 'package' => $package );
 		}
 
-		return $version;
+		$this->channel_release = $best;
+
+		return $best;
+	}
+
+
+	/**
+	 * Get New Version from GitHub
+	 *
+	 * @since 1.0
+	 * @return string|false $version the version number
+	 */
+	public function get_new_version() {
+		$release = $this->get_channel_release();
+
+		return ( false === $release ) ? false : $release['version'];
 	}
 
 
@@ -362,11 +506,15 @@ class WP_GitHub_Updater {
 		if ( empty( $transient->checked ) )
 			return $transient;
 
+		// Resolve here rather than in the constructor: this runs only when
+		// WordPress genuinely checks for updates, not on every admin request.
+		$this->resolve_remote();
+
 		// check the version and decide if it's new
 		$update = version_compare( $this->config['new_version'], $this->config['version'] );
 
 		if ( 1 === $update ) {
-      $response = new \stdClass;
+			$response = new \stdClass;
 			$response->new_version = $this->config['new_version'];
 			$response->slug = $this->config['proper_folder_name'];
 			$response->url = add_query_arg( array( 'access_token' => $this->config['access_token'] ), $this->config['github_url'] );
@@ -395,6 +543,10 @@ class WP_GitHub_Updater {
 		// Check if this call API is for the right plugin
 		if ( !isset( $response->slug ) || $response->slug != $this->config['slug'] )
 			return false;
+
+		// Only reached on this plugin's details screen, so the lookup is worth
+		// making here; every other plugins_api call costs nothing.
+		$this->resolve_remote();
 
 		$response->slug = $this->config['slug'];
 		$response->plugin_name  = $this->config['plugin_name'];


### PR DESCRIPTION
Ports the updater rework from `wp-soli-featured-image-plugin` — `6a01a32` and `ac66a1b` — as one change. They belong together: shipping only the first leaves an updater that resolves releases but still fetches on every admin page load.

## Half 1 — resolve releases instead of branch headers

Nothing installed from this repo could see an update. The updater read the `Version` header off a raw branch URL, so releases were invisible to it by design, and `raw.github.com` is a dead host. `zip_url` pointed at a branch archive, which ships the unbuilt tree — a plugin without its compiled block assets.

`get_new_version()` now resolves the newest release **in the installed version's channel** from the releases API and takes the download from that release's zip asset. Releases are ordered by version, not by GitHub's newest-created-first, so a re-published older tag cannot win. An API failure falls back to the last cached release list rather than reporting "no update".

The nightly also never stamped its version — `nightly.yml` computed `NIGHTLY_VERSION` and used it only for the tag and title, so the zip carried the stable version and no site could tell a nightly from a stable install. It is now stamped into the plugin header, `SOLI_EVENT__PLUGIN_VERSION`, `README.md` and `package.json` before `publish.js` runs, with a guard that fails the build if any stamp misses.

## Half 2 — resolve on update check, not on every admin page load

`set_defaults()` runs in the constructor, which fires on `init` for every wp-admin request, and made two API calls. Both bypass their transients because the plugin defines `WP_GITHUB_FORCE_UPDATE` as true. GitHub's unauthenticated limit is 60/hour counted **per source IP** — not per site, not per plugin — so a dozen plugins on one host exhaust it within minutes.

The lookups move into `resolve_remote()`, called from `api_check()` after its empty-transient guard and from `get_plugin_info()` after its slug guard, memoised per request. An ordinary admin page load now costs nothing, and loses up to 2s of latency per call.

`http_request_sslverify()` widens its match: the download happens in a later request than the update check, so `zip_url` may still be the unresolved fallback by then.

## Verification

- `php -l updater.php` clean.
- Full Playwright suite green: **95 passed (4.0m)**, 21 spec files.
- Channel logic exercised directly, with the real `is_nightly_version()` / `get_channel_release()` bodies extracted from the shipped `updater.php` and run against a fake release list:

```
installed 1.1.1 (stable)          -> 1.1.3
installed 1.1.1-nightly.20260801  -> 1.1.4-nightly.20260810

PASS  1. stable install sees the newest STABLE release      got='1.1.3'
PASS  2. stable install is NOT offered a nightly            got=false
PASS  3. nightly install sees the newest NIGHTLY release     got='1.1.4-nightly.20260810'
PASS  4. nightly install is NOT offered the stable build     got=true

(version_compare('1.1.3-nightly.20260812','1.1.3') = -1 — nightly sorts BELOW stable)

PASS  5. ordering is by version, not list position
PASS  6. release without a zip asset is skipped
```

- The `nightly.yml` stamp step was dry-run against this repo's real files inside a Linux container (GNU `sed`, as on `ubuntu-latest`) — all four locations stamped, all four guards pass.

**Not verified locally:** the end-to-end WordPress update path — that `api_check()` populates the plugins transient, that the details screen renders, and that the download and `upgrader_post_install` rename install correctly. That needs a live install with a published release carrying a zip asset, which this repo does not have yet.

## Differences from the reference

`proper_folder_name` was already `dirname(plugin_basename(__FILE__))` here and `raw_url` already pointed at `main`, so neither of those fixes was needed. `package.json` was already in sync at 1.1.3, so there was no version drift to correct. No version bump — the release flow owns that.
