### PR TITLE
Test the oldest supported WordPress, not just the newest

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,31 @@ jobs:
           test "$(node -p "require('./package.json').version")" = "$V"
           echo "Stamped $V into all version locations."
 
+      - name: Stamp the supported WordPress range
+        run: |
+          set -euo pipefail
+          # Both ends of the range come from what the e2e suite actually ran:
+          # 'tested' from wordpress.org's current release, 'requires' from the
+          # floor branch declared in package.json. test.yml runs a leg against
+          # each and fails if wp-env installed anything else, so neither number
+          # is a claim nobody checked.
+          WP=$(curl -sf https://api.wordpress.org/core/version-check/1.7/ \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).offers[0].current))')
+          FLOOR=$(node -p "require('./package.json').wordpress.requiresAtLeast")
+          test -n "$WP" && test -n "$FLOOR"
+
+          sed -i -E "s|('tested' => ')[^']*(')|\1${WP}\2|" soli-event-plugin.php
+          sed -i -E "s|('requires' => ')[^']*(')|\1${FLOOR}\2|" soli-event-plugin.php
+
+          for pair in "tested:${WP}" "requires:${FLOOR}"; do
+            key="${pair%%:*}"; val="${pair#*:}"
+            if ! grep -qF -- "'${key}' => '${val}'" soli-event-plugin.php; then
+              echo "::error::failed to stamp '${key}' => '${val}'"
+              exit 1
+            fi
+          done
+          echo "Stamped supported WordPress range: ${FLOOR} to ${WP}."
+
       # publish.js excludes every block's src/, so the block bundles must be
       # built before the zip is created or the plugin ships without its JS.
       - name: Build blocks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,32 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         run: npm ci
 
+      - name: Stamp the supported WordPress range
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          # Both ends of the range come from what the e2e suite actually ran:
+          # 'tested' from wordpress.org's current release, 'requires' from the
+          # floor branch declared in package.json. test.yml runs a leg against
+          # each and fails if wp-env installed anything else, so neither number
+          # is a claim nobody checked.
+          WP=$(curl -sf https://api.wordpress.org/core/version-check/1.7/ \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).offers[0].current))')
+          FLOOR=$(node -p "require('./package.json').wordpress.requiresAtLeast")
+          test -n "$WP" && test -n "$FLOOR"
+
+          sed -i -E "s|('tested' => ')[^']*(')|\1${WP}\2|" soli-event-plugin.php
+          sed -i -E "s|('requires' => ')[^']*(')|\1${FLOOR}\2|" soli-event-plugin.php
+
+          for pair in "tested:${WP}" "requires:${FLOOR}"; do
+            key="${pair%%:*}"; val="${pair#*:}"
+            if ! grep -qF -- "'${key}' => '${val}'" soli-event-plugin.php; then
+              echo "::error::failed to stamp '${key}' => '${val}'"
+              exit 1
+            fi
+          done
+          echo "Stamped supported WordPress range: ${FLOOR} to ${WP}."
+
       # publish.js excludes every block's src/, so the block bundles must be
       # built before the zip is created or the plugin ships without its JS.
       - name: Build blocks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Job id is the required status check context (must match the "PR requirements"
-  # ruleset, and the `test` name used across all Soli repos). The workflow name
-  # never appears as a check context.
-  test:
+  # One leg per WordPress version we claim to support. `floor` is the oldest
+  # supported branch, declared once in package.json as wordpress.requiresAtLeast
+  # and resolved here to its newest patch; `latest` is whatever wordpress.org
+  # currently ships. Production runs behind the newest release, so testing only
+  # the newest would leave the version actually serving soli.nl unexercised.
+  e2e:
+    name: e2e (WP ${{ matrix.channel }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [latest, floor]
 
     steps:
       - name: Checkout
@@ -29,6 +37,43 @@ jobs:
 
       - name: Install deps
         run: npm ci
+
+      - name: Resolve the WordPress version for this leg
+        id: wp
+        run: |
+          set -euo pipefail
+          FLOOR_BRANCH=$(node -p "require('./package.json').wordpress.requiresAtLeast")
+          if [ "${{ matrix.channel }}" = "latest" ]; then
+            VERSION=$(curl -sf https://api.wordpress.org/core/version-check/1.7/ \
+              | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).offers[0].current))')
+          else
+            # Newest patch on the floor branch, so security fixes are picked up
+            # without anyone editing the matrix.
+            VERSION=$(curl -sf https://api.wordpress.org/core/stable-check/1.0/ \
+              | FLOOR="$FLOOR_BRANCH" node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+                  const f=process.env.FLOOR;
+                  const k=v=>v.split(".").map(Number);
+                  const c=Object.keys(JSON.parse(s)).filter(v=>v===f||v.startsWith(f+"."));
+                  if(!c.length){console.error("no releases on branch "+f);process.exit(1);}
+                  c.sort((a,b)=>{const x=k(a),y=k(b);for(let i=0;i<3;i++){if((x[i]||0)!==(y[i]||0))return (x[i]||0)-(y[i]||0);}return 0;});
+                  console.log(c[c.length-1]);
+                })')
+          fi
+
+          test -n "$VERSION"
+          # Both legs name an explicit zip. The reference implementation leaves
+          # this empty on the latest leg and lets wp-env resolve core itself, but
+          # that path goes through the WordPress/WordPress git mirror: on
+          # 2026-08-12 WordPress shipped 7.0.4 without pushing the tag and Soli
+          # repos resolving core through git died on `couldn't find remote ref`.
+          # The zips are published with the release, so they lack that failure
+          # mode. WP_ENV_CORE supersedes the "core" pin in .wp-env.json (wp-env
+          # merges environment-variable overrides last, and sets coreSource on
+          # both the development and tests environments - see
+          # lib/config/parse-config.js), which is what lets either leg run.
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "WP_ENV_CORE=https://wordpress.org/wordpress-${VERSION}.zip" >> $GITHUB_ENV
+          echo "Leg '${{ matrix.channel }}' targets WordPress ${VERSION}"
 
       - name: Build blocks
         run: npm run build
@@ -54,6 +99,33 @@ jobs:
             sleep 5
           done
 
+      - name: Verify wp-env installed the version this leg targets
+        run: |
+          set -euo pipefail
+          # The release workflows stamp 'requires' and 'tested' from these same
+          # two numbers, so if wp-env quietly installed something else the plugin
+          # would advertise compatibility it never demonstrated.
+          # Note the run container is tests-cli, not tests.
+          RAW=$(npx wp-env run tests-cli wp core version 2>&1 | tr -d '\r')
+          ACTUAL=$(printf '%s\n' "$RAW" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | head -1 || true)
+          WANTED="${{ steps.wp.outputs.version }}"
+
+          if [ -z "$ACTUAL" ]; then
+            echo "::error::could not read the WordPress version from wp-env. Raw output:"
+            printf '%s\n' "$RAW"
+            exit 1
+          fi
+
+          echo "wp-env installed WordPress ${ACTUAL}; this leg targets ${WANTED}"
+          echo "WP ${ACTUAL} (${{ matrix.channel }})" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$ACTUAL" != "$WANTED" ]; then
+            echo "::error::wp-env installed ${ACTUAL} but this leg targets ${WANTED}."
+            echo "::error::Usual causes: WP_ENV_CORE no longer overrides the core pin in"
+            echo "::error::.wp-env.json, or WordPress released mid-run (re-run the job)."
+            exit 1
+          fi
+
       - name: Run Playwright tests
         env:
           CI: true
@@ -67,7 +139,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.channel }}
           path: playwright-report
           if-no-files-found: ignore
           retention-days: 7
@@ -76,7 +148,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.channel }}
           path: test-results
           if-no-files-found: ignore
           retention-days: 7
@@ -85,3 +157,25 @@ jobs:
       - name: Stop wp-env
         if: always()
         run: npm run wp-env:stop
+
+  # Single required status check. The branch ruleset requires the context `test`,
+  # and a matrix job reports one context per leg (`e2e (WP latest)`, `e2e (WP
+  # floor)`) rather than a bare one - so this job exists to collapse the matrix
+  # back into the name the ruleset expects. Renaming the required check instead
+  # would need a careful non-atomic ruleset change; this needs none.
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: always()
+
+    steps:
+      - name: Require every WordPress version to pass
+        run: |
+          set -euo pipefail
+          RESULT="${{ needs.e2e.result }}"
+          if [ "$RESULT" != "success" ]; then
+            echo "::error::the e2e matrix did not pass (result: ${RESULT})"
+            exit 1
+          fi
+          echo "All WordPress versions passed."

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress#7.0",
+  "core": "https://wordpress.org/wordpress-7.0.4.zip",
   "port": 8900,
   "plugins": ["."],
   "config": {

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
-![npm](https://img.shields.io/badge/npm-v9.5.0-fb8817)
-![node](https://img.shields.io/badge/node-v16.13.0-43853d)
-![wp_env](https://img.shields.io/badge/wp&dash;env-v5.12.0-40a8af)
-![wordpress](https://img.shields.io/badge/Wordpress-v6.3.1-3858e9)
+[![version](https://img.shields.io/github/package-json/v/JoranOut/wp-soli-event-plugin?label=version&color=3858e9)](https://github.com/JoranOut/wp-soli-event-plugin/releases)
+[![nightly](https://img.shields.io/github/v/release/JoranOut/wp-soli-event-plugin?include_prereleases&label=nightly&color=fb8817)](https://github.com/JoranOut/wp-soli-event-plugin/releases)
+[![tested up to](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.wordpress.org%2Fcore%2Fversion-check%2F1.7%2F&query=%24.offers%5B0%5D.current&label=tested%20up%20to&prefix=WP%20&color=40a8af)](https://wordpress.org/download/releases/)
+[![requires](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FJoranOut%2Fwp-soli-event-plugin%2Fmain%2Fpackage.json&query=%24.wordpress.requiresAtLeast&label=requires&prefix=WP%20&color=40a8af)](https://wordpress.org/download/releases/)
+[![wp-env](https://img.shields.io/github/package-json/dependency-version/JoranOut/wp-soli-event-plugin/dev/@wordpress/env?label=wp-env&color=40a8af)](https://www.npmjs.com/package/@wordpress/env)
+[![node](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FJoranOut%2Fwp-soli-event-plugin%2Fmain%2Fpackage.json&query=%24.engines.node&label=node&color=43853d)](https://nodejs.org)
 
 # WP Soli event plugin
 Plugin for wordpress dedicated to displaying events on [soli.nl](https://www.soli.nl)
 
+<!-- Machine-readable markers. publish.js reads the plugin name to name the zip,
+     and the release workflows rewrite the version here when packaging a build.
+     Kept in a comment because a single tilde renders as strikethrough on GitHub;
+     the badges above are the human-readable version. Do not reformat.
 ~Plugin Name: wp-soli-event-plugin~
 ~Current Version:1.1.3~
+-->
+
 
 Contains:
 - Custom event post-type
@@ -32,6 +40,24 @@ Contains:
 ### Stop
 ```cmd 
 wp-env stop 
+```
+
+### WordPress version
+`.wp-env.json` pins `core` to an explicit wordpress.org zip rather than a
+`WordPress/WordPress` git ref: the git mirror is not guaranteed to carry a tag
+for a fresh release (on 2026-08-12 WordPress shipped 7.0.4 without pushing one),
+and the zips are published with the release. The pin governs local development
+only. CI sets `WP_ENV_CORE` per matrix leg, which wp-env merges last and so
+supersedes this pin - that is how the suite runs against both the newest release
+and the oldest supported branch (`wordpress.requiresAtLeast` in `package.json`).
+
+To reproduce a CI leg locally, destroy the environment first - downgrading core
+under an existing database leaves WordPress demanding a database update and most
+admin tests fail on that screen:
+
+```cmd
+wp-env destroy
+WP_ENV_CORE=https://wordpress.org/wordpress-6.9.7.zip wp-env start
 ```
 
 ## Mysql container

--- a/e2e/php-errors.spec.ts
+++ b/e2e/php-errors.spec.ts
@@ -46,7 +46,16 @@ test.describe('PHP diagnostics', () => {
     }) => {
         await page.goto('/wp-admin/site-health.php?tab=debug');
         // The "WordPress Constants" table lives in a collapsed accordion panel.
-        await page.locator('#health-check-section-wp-constants').click();
+        // Target the trigger by aria-controls rather than by its own id: WordPress
+        // only added `id="health-check-section-*"` to that button in 7.0, so an
+        // id selector silently times out on the floor leg of the matrix, while
+        // aria-controls is the a11y contract its own JS relies on and is present
+        // in every version the suite runs against.
+        await page
+            .locator(
+                'button[aria-controls="health-check-accordion-block-wp-constants"]'
+            )
+            .click();
         const panel = page.locator('#health-check-accordion-block-wp-constants');
 
         for (const constant of ['WP_DEBUG', 'WP_DEBUG_DISPLAY']) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
     "test:playwright:debug": "wp-scripts test-playwright --debug",
     "test:playwright:headed": "wp-scripts test-playwright --headed"
   },
+  "engines": {
+    "node": ">=20"
+  },
+  "wordpress": {
+    "_comment": "Oldest supported WordPress branch. The e2e suite runs against the newest patch of this branch as well as the newest release, and the release workflows stamp it into the plugin's 'requires'. Raise it when production no longer runs it.",
+    "requiresAtLeast": "6.9"
+  },
   "workspaces": [
     "events/blocks/create-event",
     "events/blocks/event-reservation-popup",

--- a/soli-event-plugin.php
+++ b/soli-event-plugin.php
@@ -72,8 +72,12 @@ add_action('init', function () {
       // releases API and overrides this with the release's zip asset.
       'zip_url' => 'https://github.com/JoranOut/wp-soli-event-plugin/releases/latest/download/wp-soli-event-plugin.zip', // the zip url of the GitHub repo
       'sslverify' => true, // whether WP should check the validity of the SSL cert when getting an update, see https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/2 and https://github.com/jkudish/WordPress-GitHub-Plugin-Updater/issues/4 for details
-      'requires' => '6.0.0', // which version of WordPress does your plugin require?
-      'tested' => '6.6.6',  // which version of WordPress is your plugin tested up to?
+      'requires' => '6.9', // oldest branch the e2e suite covers; see package.json wordpress.requiresAtLeast
+      // Both ends of the range are rewritten at packaging time by the nightly
+      // and release workflows to the WordPress versions the e2e suite actually
+      // ran against, so the plugin screen stops reporting "compatibility not
+      // tested". Do not reformat.
+      'tested' => '7.0.4',  // which version of WordPress is your plugin tested up to?
       'readme' => 'README.md', // which file to use as the readme for the version number
     );
 


### PR DESCRIPTION
Ports the WordPress test matrix and version stamping from `wp-soli-featured-image-plugin` (`d291e98` + `3d657c9`) as one change.

## What changes

- **`test.yml` gains a matrix** over `channel: [latest, floor]`. `latest` comes from `api.wordpress.org/core/version-check/1.7/` (currently **7.0.4**); `floor` is the newest patch on the branch declared as `wordpress.requiresAtLeast` in `package.json`, resolved from `core/stable-check/1.0/` (**6.9** → **6.9.7**). A step reads `wp core version` back out of `tests-cli` and fails if wp-env installed anything else.
- **The job id stays `test`** where the ruleset needs it. The matrix legs report `e2e (WP latest)` / `e2e (WP floor)`, and a dependent `test` job collapses them into the single required context — no ruleset change needed.
- **`release.yml` and `nightly.yml` stamp `requires` and `tested`** from those same two numbers. `requires` was `6.0.0` and `tested` was `6.6.6`; neither had been run against in years. The nightly's existing plugin-version stamping step is untouched — the WordPress range is a second step beside it.
- **README badges become self-updating** (shields endpoints reading `package.json`, the releases API and wordpress.org). The `~Plugin Name~` / `~Current Version:1.1.3~` markers move into an HTML comment; `publish.js` and the nightly's sed both still match them, including the missing space after the colon.

## Deviations from the reference

**Both legs name an explicit zip.** The reference sets `CORE=""` on the latest leg, which resolves through the `WordPress/WordPress` git mirror — the path that broke on 2026-08-12 when WordPress shipped 7.0.4 without pushing the tag. `WP_ENV_CORE` is set to `https://wordpress.org/wordpress-${VERSION}.zip` on both legs.

**`.wp-env.json`'s core pin.** This repo alone pinned `WordPress/WordPress#7.0`, a git *branch head* — which is why it survived 2026-08-12, and also why it tests an older release than every sibling and silently drifts. Replaced with the 7.0.4 zip: same failure-mode immunity, deterministic, and consistent with the siblings. It governs local development only; CI overrides it per leg.

Verified empirically rather than assumed: with the pin in place and `WP_ENV_CORE` naming the 6.9.7 zip, `wp core version` in `tests-cli` reports `6.9.7`. wp-env merges environment-variable overrides last and sets `coreSource` on both the development and tests environments (`lib/config/parse-config.js`).

## One test fix the floor leg required

`e2e/php-errors.spec.ts` clicked the Site Health accordion by `#health-check-section-wp-constants`. WordPress only added that `id` to the button in 7.0, so on 6.9 the click timed out — taking down the assertion that keeps every other PHP-error assertion honest. It now targets the trigger by `aria-controls`, which WordPress' own JS relies on and which is present in both. This is a test-portability fix, not a plugin incompatibility: every functional spec passed on 6.9.7 unchanged.

## Verification

- Full suite on **7.0.4**: 95 passed.
- Full suite on **6.9.7**: 94 passed, 1 failed — the selector above; that spec passes on 6.9.7 after the fix.
- Stamping dry-run under GNU sed in `node:24-bookworm-slim` against copies of the real files: all four version locations plus `requires`/`tested` stamp and pass their guards.
- Both wordpress.org APIs called directly: 7.0.4 and 6.9.7.

No version bump.