### PR TITLE
Version nightlies by commit count instead of date

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # rev-list --count needs the whole history, not the default shallow clone
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,16 +29,43 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get current version and date
+      - name: Get current version and build number
         id: version
         run: |
+          set -euo pipefail
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          DATE=$(date +'%Y%m%d')
-          NIGHTLY_VERSION="${CURRENT_VERSION}-nightly.${DATE}"
+          # The build number has to be monotonic, because the updater decides
+          # whether to offer an update with version_compare(). A commit count is
+          # monotonic and only moves when commits land, so an idle repo keeps
+          # producing the same version and no site is nagged. A date bumps daily
+          # whether or not anything changed, and a short SHA cannot be used at
+          # all: version_compare() orders SHAs arbitrarily, so roughly half of
+          # all builds would compare as "not newer" and never install.
+          BUILD=$(git rev-list --count HEAD)
+          NIGHTLY_VERSION="${CURRENT_VERSION}-nightly.${BUILD}"
           echo "nightly_version=${NIGHTLY_VERSION}" >> $GITHUB_OUTPUT
-          echo "date=${DATE}" >> $GITHUB_OUTPUT
+          echo "build=${BUILD}" >> $GITHUB_OUTPUT
+          echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Skip when main has not moved
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.version.outputs.nightly_version }}
+        run: |
+          set -euo pipefail
+          # Same commit count means no commits since the last nightly. Re-cutting
+          # an identical release would only churn the tag and re-upload the same
+          # zip, so stop here instead.
+          if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            echo "$TAG already exists - no commits since the last nightly, nothing to publish."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Stamp nightly version
+        if: steps.guard.outputs.skip != 'true'
         env:
           V: ${{ steps.version.outputs.nightly_version }}
         run: |
@@ -63,6 +93,7 @@ jobs:
           echo "Stamped $V into all version locations."
 
       - name: Stamp the supported WordPress range
+        if: steps.guard.outputs.skip != 'true'
         run: |
           set -euo pipefail
           # Both ends of the range come from what the e2e suite actually ran:
@@ -90,14 +121,17 @@ jobs:
       # publish.js excludes every block's src/, so the block bundles must be
       # built before the zip is created or the plugin ships without its JS.
       - name: Build blocks
+        if: steps.guard.outputs.skip != 'true'
         run: npm run build
 
       - name: Build package
+        if: steps.guard.outputs.skip != 'true'
         run: |
           # Skip the i18n build for nightly (it requires a running wp-env)
           node ./publish.js
 
       - name: Delete previous nightly release
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -109,15 +143,20 @@ jobs:
           done
 
       - name: Create nightly release
+        if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "v${{ steps.version.outputs.nightly_version }}" \
-            --title "Nightly Build ${{ steps.version.outputs.date }}" \
+            --title "Nightly Build ${{ steps.version.outputs.nightly_version }}" \
             --notes "Automated nightly build from main branch.
 
           **Version:** ${{ steps.version.outputs.nightly_version }}
-          **Built from:** ${{ github.sha }}
+          **Build:** ${{ steps.version.outputs.build }} commits on main
+          **Built from:** ${{ github.sha }} on ${{ steps.version.outputs.date }}
+
+          The build number is the commit count, so this version only changes
+          when commits land - an idle repo will not prompt sites to update.
 
           This is a pre-release build for testing purposes." \
             --prerelease \


### PR DESCRIPTION
Ports `248d81c` from `wp-soli-featured-image-plugin`. Workflow file only; no plugin version bump, no migration for the existing date-based nightly.

## What changes

- `BUILD=$(git rev-list --count HEAD)`; the nightly version becomes `{stable}-nightly.{BUILD}`.
- Checkout gains `fetch-depth: 0` — `rev-list --count` needs full history, not the default shallow clone.
- A guard step skips the whole run when the release for the computed tag already exists (main has not moved).

## Why a counter

The updater decides whether to offer an update with `version_compare()`, so the build number must be monotonic. A commit count only moves when commits land, so an idle repo keeps producing the same version and no site is nagged; a date bumps daily whether or not anything changed. A short SHA cannot be used at all — `version_compare()` orders SHAs arbitrarily, so roughly half of all builds would compare as "not newer" and never install.

## Integration with what was already here

Both existing stamp steps (`Stamp nightly version`, `Stamp the supported WordPress range`) are untouched apart from the guard `if:`. They already read `steps.version.outputs.nightly_version`, so they pick up the commit-count version without modification. The guard also gates `Build blocks`, `Build package`, `Delete previous nightly release` and `Create nightly release`.

## Differences from the reference

- This repo has a separate `Build blocks` step ahead of `Build package` (the reference folds `npm run build` into one step); both are guarded.
- Its stamp verification uses per-line `grep` guards rather than the reference `for check in …` loop; left as is.
- `checkout@v4` / `setup-node@v4` / Node 20 are left alone — out of scope for this port.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses.
- `git rev-list --count HEAD` on this branch: **120**, so the first build after merge is `{stable}-nightly.120`.
- Traced the version through every consumer: release tag, release title, release notes, both stamp steps, and the zip. `publish.js` names the zip from the plugin name only (`${pluginName}.zip`, globbed as `*.zip`), so its *contents* carry the version via the stamp steps — no date reaches any of them.

Not dispatched: `main` still carries the old workflow until this merges.