### PR TITLE
Show orchestra and address in the concert-hero card

### DIFF
--- a/e2e/concert_hero.spec.ts
+++ b/e2e/concert_hero.spec.ts
@@ -42,13 +42,12 @@ test.describe('Concert Hero Block', () => {
 
         // A real concert row was joined and formatted: the title is non-empty
         // and the program card shows a real start time ("HH:MM hrs") next to
-        // the day/start labels.
+        // the start label.
         await expect(page.locator('.soli-concert-hero__title')).not.toBeEmpty();
         // The title splits into a two-tone display; the last word is always the
         // accent span, so it is present for any (non-empty) concert title.
         await expect(page.locator('.soli-concert-hero__title-accent')).toBeVisible();
         const card = page.locator('.soli-concert-hero__card');
-        await expect(card).toContainText('Day');
         await expect(card).toContainText('Start');
         await expect(card).toContainText(/\d{1,2}:\d{2}\s*hrs/);
     });

--- a/events/blocks/concert-hero/index.php
+++ b/events/blocks/concert-hero/index.php
@@ -63,7 +63,6 @@ class SoliBlockConcertHero {
 
     $start_ts   = strtotime($concert['start_date']);
     $full_date  = ucfirst(date_i18n('l j F Y', $start_ts));
-    $day        = ucfirst(date_i18n('l', $start_ts));
     $start_time = date_i18n('H:i', $start_ts);
 
     $title    = \Soli\Events\EventVisibility::maskTitle($concert['status'] ?? null, $concert['post_title']);
@@ -98,6 +97,17 @@ class SoliBlockConcertHero {
 
     $loc_name = isset($concert['location_name']) ? $concert['location_name'] : '';
     $loc_addr = isset($concert['location_address']) ? $concert['location_address'] : '';
+
+    // The orchestra(s) performing: the event's categories under the
+    // 'orkesten' parent. Other categories are not orchestras and stay hidden.
+    $orchestra = '';
+    if (!empty($concert['post_id'])) {
+      $terms = get_the_terms((int) $concert['post_id'], 'category');
+      if ($terms && !is_wp_error($terms)) {
+        $terms = \Soli\Events\OrkestenCategories::filterTerms($terms);
+        $orchestra = implode(', ', wp_list_pluck($terms, 'name'));
+      }
+    }
 
     $wrapper = get_block_wrapper_attributes(array('class' => 'soli-concert-hero'));
 
@@ -137,16 +147,19 @@ class SoliBlockConcertHero {
             <p class="soli-concert-hero__card-date"><?php echo esc_html($full_date); ?></p>
             <hr class="soli-concert-hero__card-rule" />
             <dl class="soli-concert-hero__card-list">
-              <dt><?php esc_html_e('Day', 'soli-event'); ?></dt>
-              <dd><?php echo esc_html($day); ?></dd>
+              <?php if ($orchestra) : ?>
+                <dt><?php esc_html_e('Orchestra', 'soli-event'); ?></dt>
+                <dd><?php echo esc_html($orchestra); ?></dd>
+              <?php endif; ?>
               <dt><?php esc_html_e('Start', 'soli-event'); ?></dt>
               <dd><?php echo esc_html($start_time); ?> <?php esc_html_e('hrs', 'soli-event'); ?></dd>
               <?php if ($loc_name) : ?>
                 <dt><?php esc_html_e('Location', 'soli-event'); ?></dt>
-                <dd>
-                  <?php echo esc_html($loc_name); ?>
-                  <?php if ($loc_addr) : ?><br /><span class="soli-concert-hero__card-muted"><?php echo esc_html($loc_addr); ?></span><?php endif; ?>
-                </dd>
+                <dd><?php echo esc_html($loc_name); ?></dd>
+              <?php endif; ?>
+              <?php if ($loc_addr) : ?>
+                <dt><?php esc_html_e('Address', 'soli-event'); ?></dt>
+                <dd><span class="soli-concert-hero__card-muted"><?php echo esc_html($loc_addr); ?></span></dd>
               <?php endif; ?>
             </dl>
             <?php if ($event_url) : ?>

--- a/events/blocks/concert-hero/src/index.scss
+++ b/events/blocks/concert-hero/src/index.scss
@@ -206,6 +206,7 @@
     gap: 12px 20px;
     font-family: var(--sch-font-sans);
     font-size: 14px;
+    align-items: flex-end;
 
     dt {
       font-size: 11px;

--- a/events/events.php
+++ b/events/events.php
@@ -34,6 +34,7 @@ require_once 'lib/events_admin_view_page.php';
 require_once 'lib/events_admin_log_page.php';
 require_once 'lib/plugin_settings_page.php';
 require_once 'lib/category_onderdeel.php';
+require_once 'lib/orkesten_categories.php';
 require_once 'inc/values.php';
 require_once 'blocks/create-event/index.php';
 require_once 'blocks/event-view-calendar/index.php';

--- a/events/lib/orkesten_categories.php
+++ b/events/lib/orkesten_categories.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Soli\Events;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+/**
+ * Orchestras are communicated through the category taxonomy, but only the
+ * categories nested under the parent category with slug 'orkesten' count.
+ * Categories outside that parent (news, generic tags, ...) must never be
+ * presented as an orchestra. When the 'orkesten' parent does not exist on a
+ * site, no category qualifies at all.
+ */
+class OrkestenCategories {
+
+  const PARENT_SLUG = 'orkesten';
+
+  // Term ids of every category under the 'orkesten' parent (all depths).
+  // Empty array when the parent category does not exist.
+  public static function ids() {
+    $parent = get_term_by('slug', self::PARENT_SLUG, 'category');
+    if (!$parent || is_wp_error($parent)) {
+      return array();
+    }
+    $children = get_term_children($parent->term_id, 'category');
+    if (is_wp_error($children)) {
+      return array();
+    }
+    return array_map('intval', $children);
+  }
+
+  // Keep only the orchestra categories from a list of WP_Term objects.
+  public static function filterTerms($terms) {
+    if (empty($terms) || !is_array($terms)) {
+      return array();
+    }
+    $ids = self::ids();
+    return array_values(array_filter($terms, function ($term) use ($ids) {
+      return in_array((int) $term->term_id, $ids, true);
+    }));
+  }
+}


### PR DESCRIPTION
## Changes
- The concert-hero card replaces the Day row with an **Orchestra** row (the full date line already names the weekday) and gives the venue address its own **Address** row.
- Orchestras come from the event's categories, but only categories under the parent category with slug `orkesten` count — new `Soli\Events\OrkestenCategories` helper. If that parent category does not exist, no category qualifies and the row is hidden.
- Card list gets `align-items: flex-end`.
- e2e: dropped the `Day` assertion in `concert_hero.spec.ts`.

Companion PR in wp-soli-featured-image-plugin applies the same orkesten-parent rule to its category-image mapping.