### PR TITLE
Read assignments from wp-soli-oidc-client-plugin meta key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,8 @@ location row. A date with neither location nor rooms stays hidden.
 
 "Mijn orkesten" panel for the members page (`events/blocks/my-groups/`, ported from the theme's
 `page-mijn-pagina` pattern): the logged-in member's groups, each with its next upcoming event. Group
-membership comes from the **SSO assignments** the passport plugin syncs at login (user meta
-`soli_passport_assignments`, written by laravel-soli-administration's `assignments` claim); each entry only
+membership comes from the **SSO assignments** the wp-soli-oidc-client-plugin syncs at login (user meta
+`soli_oidc_assignments`, written by laravel-soli-administration's `assignments` claim); each entry only
 carries a numeric `onderdeel_id`, so editors link a category to its administration group once via a
 term-meta field on the category add/edit screens (`soli_event_onderdeel_id`,
 `events/lib/category_onderdeel.php` — also exposes the `soli_event_user_onderdeel_ids` filter). Per matched

--- a/e2e/fixtures/dev-my-groups.php
+++ b/e2e/fixtures/dev-my-groups.php
@@ -91,7 +91,7 @@ $user = get_user_by( 'login', 'admin' );
 if ( $user ) {
 	update_user_meta(
 		$user->ID,
-		'soli_passport_assignments',
+		'soli_oidc_assignments',
 		array(
 			array( 'onderdeel_id' => 101, 'instrument_soort_id' => 1, 'instrument_soort' => 'Bugel', 'instrument_familie' => 'Koper' ),
 			array( 'onderdeel_id' => 102, 'instrument_soort_id' => 2, 'instrument_soort' => 'Gitaar', 'instrument_familie' => 'Overig' ),

--- a/e2e/fixtures/seed.php
+++ b/e2e/fixtures/seed.php
@@ -169,7 +169,7 @@ $catalogue['_categories'] = array('viz-nc' => $cat_nc, 'viz-nc-priv' => $cat_pri
 // has a PLANNED date BEFORE its PUBLIC one, so the panel showing the +3d date
 // proves workflow states are skipped; group B only has a PLANNED date, so it
 // renders the "no upcoming events" label. viz_subscriber (section 4) carries
-// the matching soli_passport_assignments meta.
+// the matching soli_oidc_assignments meta.
 $cat_mg_a = $ensure_cat('viz-mg-a', 'VIZ Mijn Groep A');
 $cat_mg_b = $ensure_cat('viz-mg-b', 'VIZ Mijn Groep B');
 update_term_meta($cat_mg_a, 'soli_event_onderdeel_id', 9001);
@@ -299,7 +299,7 @@ $mg_user = get_user_by( 'login', 'viz_subscriber' );
 if ( $mg_user ) {
 	update_user_meta(
 		$mg_user->ID,
-		'soli_passport_assignments',
+		'soli_oidc_assignments',
 		array(
 			array( 'onderdeel_id' => 9001, 'instrument_soort_id' => 1, 'instrument_soort' => 'Bugel', 'instrument_familie' => 'Koper' ),
 			array( 'onderdeel_id' => 9002, 'instrument_soort_id' => 2, 'instrument_soort' => 'Kleine trom', 'instrument_familie' => 'Slagwerk' ),

--- a/e2e/my-groups.spec.ts
+++ b/e2e/my-groups.spec.ts
@@ -4,7 +4,7 @@
  * Seeded fixtures (seed.php §3c + §4):
  *   viz-mg-a (onderdeel 9001): mg-a-planned (PLANNED, +1d) + mg-a-public (PUBLIC, +3d)
  *   viz-mg-b (onderdeel 9002): mg-b-planned (PLANNED, +2d) only
- *   viz_subscriber carries soli_passport_assignments for 9001 + 9002;
+ *   viz_subscriber carries soli_oidc_assignments for 9001 + 9002;
  *   viz_editor has no assignments (exercises the editor-only empty note).
  *
  * Locks: assignments→category resolution via term meta, per-group "next date"

--- a/events/lib/category_onderdeel.php
+++ b/events/lib/category_onderdeel.php
@@ -8,8 +8,8 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
  * Links event categories to "onderdelen" (orchestras/groups) in the Soli
  * administration (laravel-soli-administration).
  *
- * At SSO login the passport plugin stores the user's group memberships in the
- * 'soli_passport_assignments' user meta; each entry only carries the numeric
+ * At SSO login the wp-soli-oidc-client-plugin stores the user's group memberships in the
+ * 'soli_oidc_assignments' user meta; each entry only carries the numeric
  * onderdeel_id of a group, never its name. That id is opaque to WordPress, so
  * an editor maps it once per category via a field on the category add/edit
  * screens (term meta 'soli_event_onderdeel_id'). The my-groups block resolves
@@ -19,9 +19,9 @@ class CategoryOnderdeel {
 
   const TERM_META_KEY = 'soli_event_onderdeel_id';
 
-  // Written by wp-soli-passport-plugin (Role_Sync::ASSIGNMENTS_META_KEY); read
-  // by key so this plugin works without a hard dependency on the passport class.
-  const ASSIGNMENTS_META_KEY = 'soli_passport_assignments';
+  // Written by wp-soli-oidc-client-plugin (Assignments_Sync::META_KEY); read
+  // by key so this plugin works without a hard dependency on that class.
+  const ASSIGNMENTS_META_KEY = 'soli_oidc_assignments';
 
   function __construct() {
     add_action('init', array($this, 'registerTermMeta'));
@@ -107,7 +107,7 @@ class CategoryOnderdeel {
 
     /**
      * Filter the onderdeel ids resolved for a user, e.g. to source memberships
-     * from something other than the passport assignments meta.
+     * from something other than the OIDC assignments meta.
      *
      * @param int[] $ids     Unique onderdeel ids.
      * @param int   $user_id WordPress user id.


### PR DESCRIPTION
## Changes
- Switch the assignments user-meta key from `soli_passport_assignments` (legacy wp-soli-passport-plugin) to `soli_oidc_assignments`, written by the canonical wp-soli-oidc-client-plugin's `Assignments_Sync`.
- Update e2e fixtures, spec comments, and CLAUDE.md to match.