### PR TITLE
Resolve my-groups categories by onderdeel slug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,12 @@ location row. A date with neither location nor rooms stays hidden.
 "Mijn orkesten" panel for the members page (`events/blocks/my-groups/`, ported from the theme's
 `page-mijn-pagina` pattern): the logged-in member's groups, each with its next upcoming event. Group
 membership comes from the **SSO assignments** the wp-soli-oidc-client-plugin syncs at login (user meta
-`soli_oidc_assignments`, written by laravel-soli-administration's `assignments` claim); each entry only
-carries a numeric `onderdeel_id`, so editors link a category to its administration group once via a
-term-meta field on the category add/edit screens (`soli_event_onderdeel_id`,
-`events/lib/category_onderdeel.php` — also exposes the `soli_event_user_onderdeel_ids` filter). Per matched
+`soli_oidc_assignments`, written by laravel-soli-administration's `assignments` claim); each entry carries
+a numeric `onderdeel_id` plus the group's `onderdeel` name and `onderdeel_slug`. Categories resolve two
+ways, merged: automatically when the category slug equals `onderdeel_slug`, or via a term-meta field on
+the category add/edit screens (`soli_event_onderdeel_id`) for categories whose slug differs
+(`events/lib/category_onderdeel.php` — also exposes the `soli_event_user_onderdeel_ids` and
+`soli_event_user_onderdeel_slugs` filters). Per matched
 category the row shows the next visible date via `getNextConcert(only_concerts=false, category_id)`, so
 workflow-state dates never surface (F1); rows sort soonest-first, groups without an upcoming date last with
 a "no upcoming events" label. A row links to its next event's single page; a group without an upcoming

--- a/e2e/fixtures/dev-my-groups.php
+++ b/e2e/fixtures/dev-my-groups.php
@@ -93,8 +93,8 @@ if ( $user ) {
 		$user->ID,
 		'soli_oidc_assignments',
 		array(
-			array( 'onderdeel_id' => 101, 'instrument_soort_id' => 1, 'instrument_soort' => 'Bugel', 'instrument_familie' => 'Koper' ),
-			array( 'onderdeel_id' => 102, 'instrument_soort_id' => 2, 'instrument_soort' => 'Gitaar', 'instrument_familie' => 'Overig' ),
+			array( 'onderdeel_id' => 101, 'onderdeel' => 'Harmonie', 'onderdeel_slug' => 'harmonie', 'instrument_soort_id' => 1, 'instrument_soort' => 'Bugel', 'instrument_familie' => 'Koper' ),
+			array( 'onderdeel_id' => 102, 'onderdeel' => 'Funband', 'onderdeel_slug' => 'funband', 'instrument_soort_id' => 2, 'instrument_soort' => 'Gitaar', 'instrument_familie' => 'Overig' ),
 		)
 	);
 	echo "assignments set for user 'admin' (onderdeel 101 + 102)\n";

--- a/e2e/fixtures/seed.php
+++ b/e2e/fixtures/seed.php
@@ -174,6 +174,10 @@ $cat_mg_a = $ensure_cat('viz-mg-a', 'VIZ Mijn Groep A');
 $cat_mg_b = $ensure_cat('viz-mg-b', 'VIZ Mijn Groep B');
 update_term_meta($cat_mg_a, 'soli_event_onderdeel_id', 9001);
 update_term_meta($cat_mg_b, 'soli_event_onderdeel_id', 9002);
+// Group C has NO term-meta mapping: it must resolve purely through the
+// onderdeel_slug in the assignments matching the category slug.
+$cat_mg_c = $ensure_cat('viz-mg-c', 'VIZ Mijn Groep C');
+delete_term_meta($cat_mg_c, 'soli_event_onderdeel_id');
 
 $catalogue['mg-a-planned'] = $make_cat_event('mg-a-planned', $cat_mg_a, 'PLANNED', 1, false);
 $catalogue['mg-a-public']  = $make_cat_event('mg-a-public', $cat_mg_a, 'PUBLIC', 3, false);
@@ -301,8 +305,10 @@ if ( $mg_user ) {
 		$mg_user->ID,
 		'soli_oidc_assignments',
 		array(
-			array( 'onderdeel_id' => 9001, 'instrument_soort_id' => 1, 'instrument_soort' => 'Bugel', 'instrument_familie' => 'Koper' ),
-			array( 'onderdeel_id' => 9002, 'instrument_soort_id' => 2, 'instrument_soort' => 'Kleine trom', 'instrument_familie' => 'Slagwerk' ),
+			array( 'onderdeel_id' => 9001, 'onderdeel' => 'VIZ Groep A', 'onderdeel_slug' => 'viz-groep-a', 'instrument_soort_id' => 1, 'instrument_soort' => 'Bugel', 'instrument_familie' => 'Koper' ),
+			array( 'onderdeel_id' => 9002, 'onderdeel' => 'VIZ Groep B', 'onderdeel_slug' => 'viz-groep-b', 'instrument_soort_id' => 2, 'instrument_soort' => 'Kleine trom', 'instrument_familie' => 'Slagwerk' ),
+			// Only the slug links this one to a category (viz-mg-c has no term meta).
+			array( 'onderdeel_id' => 9003, 'onderdeel' => 'VIZ Mijn Groep C', 'onderdeel_slug' => 'viz-mg-c', 'instrument_soort_id' => 3, 'instrument_soort' => 'Trombone', 'instrument_familie' => 'Koper' ),
 		)
 	);
 }

--- a/e2e/my-groups.spec.ts
+++ b/e2e/my-groups.spec.ts
@@ -4,10 +4,12 @@
  * Seeded fixtures (seed.php §3c + §4):
  *   viz-mg-a (onderdeel 9001): mg-a-planned (PLANNED, +1d) + mg-a-public (PUBLIC, +3d)
  *   viz-mg-b (onderdeel 9002): mg-b-planned (PLANNED, +2d) only
- *   viz_subscriber carries soli_oidc_assignments for 9001 + 9002;
+ *   viz-mg-c: no term meta and no events — resolves purely via onderdeel_slug
+ *   viz_subscriber carries soli_oidc_assignments for 9001 + 9002 (id-mapped,
+ *   their slugs deliberately match no category) + 9003 (slug-matched only);
  *   viz_editor has no assignments (exercises the editor-only empty note).
  *
- * Locks: assignments→category resolution via term meta, per-group "next date"
+ * Locks: assignments→category resolution via term meta and via slug, per-group "next date"
  * skipping workflow states (PLANNED +1d must lose to PUBLIC +3d), the
  * no-upcoming-events label, rows linking to the next event itself, and that
  * anonymous visitors and plain members without assignments never see the
@@ -42,11 +44,13 @@ test.describe('my-groups — SSO group panel', () => {
         await view.goto(url);
 
         const rows = view.locator('.soli-my-groups .soli-my-groups__list li');
-        await expect(rows).toHaveCount(2);
+        await expect(rows).toHaveCount(3);
 
-        // Sorted soonest-first, groups without an upcoming event last: A then B.
+        // Sorted soonest-first, groups without an upcoming event last: A, then
+        // B and C (C is the slug-matched group, present without any term meta).
         await expect(rows.nth(0).locator('.soli-ork-name')).toHaveText('VIZ Mijn Groep A');
         await expect(rows.nth(1).locator('.soli-ork-name')).toHaveText('VIZ Mijn Groep B');
+        await expect(rows.nth(2).locator('.soli-ork-name')).toHaveText('VIZ Mijn Groep C');
 
         // Group A's next date is the PUBLIC +3d one, not the PLANNED +1d one.
         // The seeder derives its dates from current_time() and the block renders

--- a/events/blocks/my-groups/index.php
+++ b/events/blocks/my-groups/index.php
@@ -53,15 +53,16 @@ class SoliBlockMyGroups {
       return $this->editorNote($title, __('Shown to logged-in members only: this panel lists the groups from their Soli account.', 'soli-event'));
     }
 
-    $onderdeel_ids = \Soli\Events\CategoryOnderdeel::getUserOnderdeelIds($user_id);
-    if (empty($onderdeel_ids)) {
+    $onderdeel_ids   = \Soli\Events\CategoryOnderdeel::getUserOnderdeelIds($user_id);
+    $onderdeel_slugs = \Soli\Events\CategoryOnderdeel::getUserOnderdeelSlugs($user_id);
+    if (empty($onderdeel_ids) && empty($onderdeel_slugs)) {
       // The preview renders with YOUR account; a member logging in through SSO gets their own groups.
       return $this->editorNote($title, __('Your account has no group assignments from the Soli administration (they sync at SSO login). Members see their own groups here.', 'soli-event'));
     }
 
-    $terms = \Soli\Events\CategoryOnderdeel::getCategoriesForOnderdeelIds($onderdeel_ids);
+    $terms = \Soli\Events\CategoryOnderdeel::getCategoriesForUser($user_id);
     if (empty($terms)) {
-      return $this->editorNote($title, __('None of your groups are linked to a category yet. Set the Soli administration group ID on each group\'s category.', 'soli-event'));
+      return $this->editorNote($title, __('None of your groups are linked to a category yet. Give the category the same slug as the group in the Soli administration, or set the group ID on the category.', 'soli-event'));
     }
 
     // One row per group: the category plus its next upcoming visible date.

--- a/events/lib/category_onderdeel.php
+++ b/events/lib/category_onderdeel.php
@@ -9,11 +9,12 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
  * administration (laravel-soli-administration).
  *
  * At SSO login the wp-soli-oidc-client-plugin stores the user's group memberships in the
- * 'soli_oidc_assignments' user meta; each entry only carries the numeric
- * onderdeel_id of a group, never its name. That id is opaque to WordPress, so
- * an editor maps it once per category via a field on the category add/edit
- * screens (term meta 'soli_event_onderdeel_id'). The my-groups block resolves
- * user -> onderdeel ids -> categories through this class.
+ * 'soli_oidc_assignments' user meta; each entry carries the numeric
+ * onderdeel_id plus the group's name and slug. Categories resolve two ways,
+ * merged: automatically when the category slug equals the assignment's
+ * onderdeel_slug, or via an explicit per-category mapping on the category
+ * add/edit screens (term meta 'soli_event_onderdeel_id') for categories whose
+ * slug differs from the administration's.
  */
 class CategoryOnderdeel {
 
@@ -113,6 +114,61 @@ class CategoryOnderdeel {
      * @param int   $user_id WordPress user id.
      */
     return apply_filters('soli_event_user_onderdeel_ids', $ids, $user_id);
+  }
+
+  /**
+   * The onderdeel slugs of the groups a user belongs to, from the assignments
+   * synced at SSO login. Empty for users who never logged in through SSO or
+   * whose assignments predate the provider sending 'onderdeel_slug'.
+   *
+   * @param int $user_id WordPress user id.
+   * @return string[] Unique onderdeel slugs.
+   */
+  static function getUserOnderdeelSlugs($user_id) {
+    $assignments = get_user_meta($user_id, self::ASSIGNMENTS_META_KEY, true);
+
+    $slugs = array();
+    if (is_array($assignments)) {
+      foreach ($assignments as $assignment) {
+        if (is_array($assignment) && !empty($assignment['onderdeel_slug'])) {
+          $slugs[] = sanitize_title($assignment['onderdeel_slug']);
+        }
+      }
+    }
+    $slugs = array_values(array_unique(array_filter($slugs)));
+
+    /**
+     * Filter the onderdeel slugs resolved for a user.
+     *
+     * @param string[] $slugs   Unique onderdeel slugs.
+     * @param int      $user_id WordPress user id.
+     */
+    return apply_filters('soli_event_user_onderdeel_slugs', $slugs, $user_id);
+  }
+
+  /**
+   * The categories for a user's groups: categories whose slug matches an
+   * assignment's onderdeel_slug, merged with categories explicitly mapped by
+   * onderdeel id via term meta.
+   *
+   * @param int $user_id WordPress user id.
+   * @return \WP_Term[] Unique terms, or empty when the user has no assignments.
+   */
+  static function getCategoriesForUser($user_id) {
+    $terms = self::getCategoriesForOnderdeelIds(self::getUserOnderdeelIds($user_id));
+
+    foreach (self::getUserOnderdeelSlugs($user_id) as $slug) {
+      $term = get_term_by('slug', $slug, 'category');
+      if ($term instanceof \WP_Term) {
+        $terms[] = $term;
+      }
+    }
+
+    $unique = array();
+    foreach ($terms as $term) {
+      $unique[$term->term_id] = $term;
+    }
+    return array_values($unique);
   }
 
   /**


### PR DESCRIPTION
## Changes
- `CategoryOnderdeel::getCategoriesForUser()`: merges slug-matched categories (category slug == assignment `onderdeel_slug`) with the existing term-meta ID mapping.
- New `soli_event_user_onderdeel_slugs` filter alongside the ids one.
- My-groups block uses the merged resolution; empty-state note mentions the slug option.
- E2E: new slug-only fixture group locks the automatic path.